### PR TITLE
refactor flags again

### DIFF
--- a/main.go
+++ b/main.go
@@ -211,13 +211,8 @@ func main() {
 
 func _main() int {
 	opt := &Opt{}
-	psr := flags.NewParser(opt, flags.HelpFlag|flags.PrintErrors|flags.PassDoubleDash)
+	psr := flags.NewParser(opt, flags.HelpFlag|flags.PassDoubleDash)
 	_, err := psr.Parse()
-	if flags.WroteHelp(err) {
-		return OK
-	} else if err != nil {
-		return UNKNOWN
-	}
 	if opt.Version {
 		if commit == "" {
 			commit = "dev"
@@ -231,6 +226,12 @@ func _main() int {
 			runtime.Version(),
 			commit)
 		return OK
+	} else if flags.WroteHelp(err) {
+		fmt.Fprintf(os.Stdout, "%v\n", err)
+		return OK
+	} else if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		return UNKNOWN
 	}
 
 	if opt.AsDaemon {


### PR DESCRIPTION
### **User description**
- Not use flags.PrintErrors, display errors and help manually
- The order should be: Version, Help, and Other Errors.


___

### **PR Type**
Enhancement


___

### **Description**
- Remove automatic flag error printing

- Manually handle help and error output

- Reorder checks: Version, Help, then errors

- Improve CLI error reporting flow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Init["flags.NewParser"] -- "Remove PrintErrors" --> Handle["Manual Error Handling"]
  Handle -- "Check Version" --> Version["Print Version"]
  Handle -- "Check Help" --> Help["Print Help"]
  Handle -- "Check Errors" --> Errors["Print Errors"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Refactor flag parsing and error handling flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.go

<ul><li>Removed <code>flags.PrintErrors</code> from parser options<br> <li> Added manual help and error output using <code>fmt.Fprintf</code><br> <li> Reordered logic to check Version, then Help, then other errors</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/mackerel-plugin-maxcpu/pull/47/files#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

